### PR TITLE
only add Authorization header if token exists

### DIFF
--- a/ServiceDiscovery/.gitignore
+++ b/ServiceDiscovery/.gitignore
@@ -1,0 +1,3 @@
+build/
+**/*.egg-info/
+**/__pycache__/

--- a/ServiceDiscovery/requirements.txt
+++ b/ServiceDiscovery/requirements.txt
@@ -1,3 +1,4 @@
+werkzeug==2.0.*
 Flask==2.1.2
 Flask-Cors==3.0.10
 flask-talisman==1.0.0
@@ -11,4 +12,3 @@ numpy==1.22.4
 lxml==4.9.0
 PyGithub==1.55
 langdetect==1.0.9
-werkzeug==2.1.2

--- a/ServiceDiscovery/requirements.txt
+++ b/ServiceDiscovery/requirements.txt
@@ -11,3 +11,4 @@ numpy==1.22.4
 lxml==4.9.0
 PyGithub==1.55
 langdetect==1.0.9
+werkzeug==2.1.2

--- a/ServiceDiscovery/servicediscovery/database/database_handler.py
+++ b/ServiceDiscovery/servicediscovery/database/database_handler.py
@@ -30,7 +30,8 @@ class Database:
         database_config = ConfigReader.read_config(section="database")
         self.scheme = database_config["scheme"]
         self.host = database_config["host"]
-        self.header = {"Authorization": f"Bearer {database_config['token']}"}
+        if database_config.get('token'):
+            self.header = {"Authorization": f"Bearer {database_config['token']}"}
         self.registry_endpoint = database_config["registry_endpoint"]
         self.services_endpoint = database_config["services_endpoint"]
         self.database_endpoint = f"{self.scheme}://{self.host}"


### PR DESCRIPTION
This patch makes the database config "token" optional. Users can either set it to an empty string or omit the token completely. This is useful for DB-APIs that do not require authentication, and therefore no token.

Also closes #7 

It is necessary to pin the werkzeug dependency to version `2.0.*`. Otherwise, service-discovery will fail to start with:

```
ImportError: cannot import name 'parse_rule' from 'werkzeug.routing'
```

See https://github.com/python-restx/flask-restx/issues/460

service-discovery probably should update its dependencies as soon as there is an [updated version of flask-restx](https://github.com/python-restx/flask-restx/issues/474) available.